### PR TITLE
sort2file uses toml file for buffer option

### DIFF
--- a/apps/workers/sort2file/worker.go
+++ b/apps/workers/sort2file/worker.go
@@ -88,7 +88,7 @@ func newWorker(info string) task.Worker {
 
 	// file opts
 	wfOpt := file.NewOptions()
-	wfOpt.UseFileBuf = iOpt.UseFileBuffer
+	wfOpt.UseFileBuf = iOpt.UseFileBuffer || fOpt.UseFileBuf
 	wfOpt.FileBufDir = fOpt.FileBufDir
 	wfOpt.FileBufPrefix = fOpt.FileBufPrefix
 	wfOpt.AWSAccessKey = fOpt.AWSAccessKey


### PR DESCRIPTION
#85 Fixes issue with sort2file not using the buffer to file when selected in toml file. 