### PR TITLE
Additional file options

### DIFF
--- a/file/buf/buf.go
+++ b/file/buf/buf.go
@@ -15,7 +15,9 @@ import (
 )
 
 func NewOptions() *Options {
-	return &Options{}
+	return &Options{
+		CompressType: gzip.BestSpeed,
+	}
 }
 
 type Options struct {

--- a/file/buf/buf.go
+++ b/file/buf/buf.go
@@ -38,6 +38,10 @@ type Options struct {
 	// Writes will be compressed but reads will read raw
 	// compressed bytes.
 	Compress bool
+
+	// CompressType type of compression used on the file
+	// best speed, best compression, default
+	CompressType int
 }
 
 func NewBuffer(opt *Options) (b *Buffer, err error) {
@@ -90,7 +94,7 @@ func NewBuffer(opt *Options) (b *Buffer, err error) {
 
 	// compression
 	if opt.Compress {
-		wGzip, _ = gzip.NewWriterLevel(w, gzip.BestSpeed)
+		wGzip, _ = gzip.NewWriterLevel(w, opt.CompressType)
 		w = wGzip
 	}
 
@@ -167,7 +171,7 @@ func (bfr *Buffer) Write(p []byte) (n int, err error) {
 	return n, err
 }
 
-// Write will write to the underlying buffer. The underlying
+// WriteLine will write to the underlying buffer. The underlying
 // bytes writing will be compressed if compression was
 // specified on buffer initialization.
 //

--- a/file/buf/buf.go
+++ b/file/buf/buf.go
@@ -16,7 +16,7 @@ import (
 
 func NewOptions() *Options {
 	return &Options{
-		CompressType: gzip.BestSpeed,
+		CompressLevel: gzip.BestSpeed,
 	}
 }
 
@@ -41,9 +41,11 @@ type Options struct {
 	// compressed bytes.
 	Compress bool
 
-	// CompressType type of compression used on the file
-	// best speed, best compression, default
-	CompressType int
+	// CompressLevel type of compression used on the file
+	// gzip.BestSpeed = 1 // quick but very little compression
+	// gzip.BestCompression = 9 // smallest size but takes longer
+	// gzip.DefaultCompression = -1 // balance between speed and size
+	CompressLevel int
 
 	// KeepFailed files when using a file buffer and the
 	// copy commands fails
@@ -100,7 +102,7 @@ func NewBuffer(opt *Options) (b *Buffer, err error) {
 
 	// compression
 	if opt.Compress {
-		wGzip, _ = gzip.NewWriterLevel(w, opt.CompressType)
+		wGzip, _ = gzip.NewWriterLevel(w, opt.CompressLevel)
 		w = wGzip
 	}
 

--- a/file/file.go
+++ b/file/file.go
@@ -107,7 +107,8 @@ type Options struct {
 	//
 	// If no prefix is provided then the temp file name is just a random
 	// unique number.
-	FileBufPrefix string `toml:"-"` // default is usually 'task-type_'
+	FileBufPrefix     string `toml:"-"` // default is usually 'task-type_'
+	FileBufKeepFailed bool   `toml:"file_buf_keep_failed" commented:"true" comment:"keep the local buffer file on a upload failure"`
 }
 
 func compressionLookup(s string) int {
@@ -127,6 +128,7 @@ func s3Options(opt Options) s3.Options {
 	s3Opts.UseFileBuf = opt.UseFileBuf
 	s3Opts.FileBufDir = opt.FileBufDir
 	s3Opts.FileBufPrefix = opt.FileBufPrefix
+	s3Opts.KeepFailed = opt.FileBufKeepFailed
 	return *s3Opts
 }
 
@@ -136,6 +138,7 @@ func gcsOptions(opt Options) gcs.Options {
 	gcsOpts.UseFileBuf = opt.UseFileBuf
 	gcsOpts.FileBufDir = opt.FileBufDir
 	gcsOpts.FileBufPrefix = opt.FileBufPrefix
+	gcsOpts.KeepFailed = opt.FileBufKeepFailed
 	return *gcsOpts
 }
 

--- a/file/file.go
+++ b/file/file.go
@@ -75,7 +75,7 @@ type Writer interface {
 // NewOptions
 func NewOptions() *Options {
 	return &Options{
-		Compression: "speed",
+		CompressionLevel: "speed",
 	}
 }
 
@@ -85,7 +85,7 @@ type Options struct {
 	AccessKey string `toml:"access_key"`
 	SecretKey string `toml:"secret_key"`
 
-	Compression string `toml:"file_compression" commented:"true" comment:"gzip compression level (speed|size|default)"`
+	CompressionLevel string `toml:"file_compression" commented:"true" comment:"gzip compression level (speed|size|default)"`
 
 	// UseFileBuf specifies to use a tmp file for the delayed writing.
 	// Can optionally also specify the tmp directory and tmp name
@@ -124,7 +124,7 @@ func compressionLookup(s string) int {
 
 func s3Options(opt Options) s3.Options {
 	s3Opts := s3.NewOptions()
-	s3Opts.CompressType = compressionLookup(opt.Compression)
+	s3Opts.CompressLevel = compressionLookup(opt.CompressionLevel)
 	s3Opts.UseFileBuf = opt.UseFileBuf
 	s3Opts.FileBufDir = opt.FileBufDir
 	s3Opts.FileBufPrefix = opt.FileBufPrefix
@@ -134,7 +134,7 @@ func s3Options(opt Options) s3.Options {
 
 func gcsOptions(opt Options) gcs.Options {
 	gcsOpts := gcs.NewOptions()
-	gcsOpts.CompressType = compressionLookup(opt.Compression)
+	gcsOpts.CompressLevel = compressionLookup(opt.CompressionLevel)
 	gcsOpts.UseFileBuf = opt.UseFileBuf
 	gcsOpts.FileBufDir = opt.FileBufDir
 	gcsOpts.FileBufPrefix = opt.FileBufPrefix
@@ -144,7 +144,7 @@ func gcsOptions(opt Options) gcs.Options {
 
 func localOptions(opt Options) local.Options {
 	localOpts := local.NewOptions()
-	localOpts.CompressType = compressionLookup(opt.Compression)
+	localOpts.CompressLevel = compressionLookup(opt.CompressionLevel)
 	localOpts.UseFileBuf = opt.UseFileBuf
 	localOpts.FileBufDir = opt.FileBufDir
 	localOpts.FileBufPrefix = opt.FileBufPrefix

--- a/file/gcs/gcs.go
+++ b/file/gcs/gcs.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	// GCS endpoint (s3 compatible api)
+	// StoreHost is a GCS endpoint (s3 compatible api)
 	StoreHost = "storage.googleapis.com"
 
 	// map that maintains gcs clients


### PR DESCRIPTION
New File options
- Compression --  option to choose compression level (best speed, compression or default)
  - this lets the user decide if they want to sacrifice speed for compression. 
- FileBufKeepFailed -- option to keep a the created buffer file if used when an error is returned on a writer.Close for aws and gcs. 
   - this is useful for debugging or for keeping logs that are not idempotent 