### PR TITLE
Update workflow and backloader for job filter

### DIFF
--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -22,6 +22,10 @@ type Phase struct {
 	Template  string // template used to create the task
 }
 
+func (p Phase) IsEmpty() bool {
+	return p.Task == "" && p.Rule == "" && p.DependsOn == "" && p.Template == ""
+}
+
 type Workflow struct {
 	Checksum string  // md5 hash for the file to check for changes
 	Phases   []Phase `toml:"phase"`

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -74,9 +74,34 @@ func (c *Cache) Get(t task.Task) Phase {
 
 	values, _ := url.ParseQuery(t.Meta)
 	key := values.Get("workflow")
+	job := values.Get("job")
+
+	if key == "*" { // search all workflows for first match
+		for _, phases := range c.Workflows {
+			for _, w := range phases.Phases {
+				if w.Task == t.Type {
+					if job == "" {
+						return w
+					}
+					v, _ := url.ParseQuery(w.Rule)
+					if v.Get("job") == job {
+						return w
+					}
+				}
+			}
+		}
+		return Phase{}
+	}
+
 	for _, w := range c.Workflows[key].Phases {
 		if w.Task == t.Type {
-			return w
+			if job == "" {
+				return w
+			}
+			v, _ := url.ParseQuery(w.Rule)
+			if v.Get("job") == job {
+				return w
+			}
 		}
 	}
 


### PR DESCRIPTION
Workflow 
- Get will distinguish phases based on the task and job (found in the rule)
- Get will search all files in a wildcard is used (meta:workflow=*)
- New Phase.IsEmpty()
Backloader
- Support from getting templates from workflows by using a config file and optionally a job flag. 
```
./backloader -c conf.toml -at 2020-02-06T00 -t "task.bigquery" -job=rev
```
