### PR TITLE
bq-load app update

### DIFF
--- a/apps/taskmasters/flowlord/taskmaster_test.go
+++ b/apps/taskmasters/flowlord/taskmaster_test.go
@@ -88,7 +88,7 @@ func TestTaskMaster_Process(t *testing.T) {
 				ID:     "UUID_task1",
 				Meta:   "retry=3&workflow=f1.toml"},
 			Expected: []task.Task{
-				task.Task{
+				{
 					Type:   "task1",
 					Info:   "?date=2019-12-12",
 					ID:     "UUID_task1",

--- a/apps/utils/filewatcher/README.md
+++ b/apps/utils/filewatcher/README.md
@@ -20,7 +20,7 @@
   - `path_template` (rule options)
     - the base path template to be searched for file changes
     - `tmpl.Parse` is used to parse the `path_template`
-  - `task_template`
+  - `task_template` (rule option)
     - the template for the info string to send to the task_topic
     - should be a uri object
     - `origin[?query]`

--- a/apps/utils/filewatcher/README.md
+++ b/apps/utils/filewatcher/README.md
@@ -1,17 +1,34 @@
 ### File Watcher
-   
-- The file-watcher creates a file on the bus when a new file has been detected in the templated path
-- by default the check happens for the past 24 hours each hour
 
-##### Option Params:
-- topic
-  - default files topic is 'files' but can be over written
-- lookback
-  - the amount of time to check back for file changes (for each directory)
-- path_template
-  - the base path template to be searched for file changes uses a year/month/day/hour file template lookup
-- aws_access_key & aws_secret_key
-  - must be provided to access the S3 bucket
-- frequency
-  - the duration between times when the path is checked for new files
+- The filewatcher can create a file message in the files_topic in the bus
+- it can also create a task message in the task_topic in the bus
+- filewatcher options
+  - `access_key` & `secret_key` (config option)
+    - must be provided to access the S3 / GCS files
+  - `files_topic` (config option)
+    - a `stat.Stat` json object is sent to the files_topic
+    - this can be disabled using a `-`
+  - `task_topic` (config option)
+    - a `task` is created and sent to the task_topic
+    - the task info is created using the `task_template` in the RULE
+    - if left empty a task is not created
+  - `lookback` (rule option)
+    - the number of hours to lookback for file changes
+  - `frequency` (rule option)
+    - the duration between times when the path is checked for new files
+    - follows go duration standard `1h`, `1m`, `10s`, `100ms`
+  - `path_template` (rule options)
+    - the base path template to be searched for file changes
+    - `tmpl.Parse` is used to parse the `path_template`
+  - `task_template`
+    - the template for the info string to send to the task_topic
+    - should be a uri object
+    - `origin[?query]`
+    - uses `{WATCH_FILE}` to pass the found file name.
+  - ```toml
+	frequency = "1h"
+	task_template = "{WATCH_FILE}?&param=data&dest=gs://dir/{HOUR_SLUG}/file.json"
+	lookback = 24
+	path_template = "gs://folder/{HOUR_SLUG}/*.json"
+   ```
 

--- a/apps/utils/filewatcher/main.go
+++ b/apps/utils/filewatcher/main.go
@@ -15,7 +15,14 @@ import (
 
 const (
 	appName     = "filewatcher"
-	description = `creates tasks for new files that appear in a watched folder`
+	description = `creates tasks for new files that appear in a watched folder
+use {WATCH_FILE} for templating file path into the info string for a new task
+
+example rule:
+	frequency = "1h"
+	info_template = "{WATCH_FILE}?&param=other-param&dest=gs://folder/{HOUR_SLUG}/file.json"
+	lookback = 24
+	path_template = "gs://folder/{HOUR_SLUG}/*.json"`
 )
 
 type options struct {
@@ -23,7 +30,8 @@ type options struct {
 
 	AccessKey  string  `toml:"access_key" desc:"secret token for S3/GCS access "`
 	SecretKey  string  `toml:"secret_key" desc:"secret key for S3/GCS access "`
-	FilesTopic string  `toml:"files_topic" desc:"topic override (default is files)"`
+	FilesTopic string  `toml:"files_topic" desc:"topic override (default is files) disable with -"`
+	InfoTopic  string  `toml:"info_topic" desc:"topic to send new task"`
 	Rules      []*Rule `toml:"rule"`
 }
 
@@ -31,6 +39,7 @@ type Rule struct {
 	HourLookback int    `toml:"lookback" desc:"the number of hours for looking back for files in previous directory default: 24"`
 	PathTemplate string `toml:"path_template" desc:"source file path pattern to match (supports glob style matching)"`
 	Frequency    string `toml:"frequency" desc:"the wait time between checking for new files in the path_template"`
+	InfoTemplate string `toml:"info_template" desc:"the template for the info string to send to the info_topic"`
 }
 
 func (o options) Validate() error {
@@ -51,6 +60,14 @@ func main() {
 	opt := &options{
 		Bus:        bus.NewOptions(""),
 		FilesTopic: "files",
+		Rules: []*Rule{
+			{
+				HourLookback: 24,
+				PathTemplate: "gs://folder/{HOUR_SLUG}/*.json",
+				Frequency:    "1h",
+				InfoTemplate: "{FILE_PATH}?&param=other-param&dest=gs://folder/{HOUR_SLUG}/file.json",
+			},
+		},
 	}
 
 	bootstrap.NewUtility(appName, opt).
@@ -68,7 +85,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	for i, _ := range watchers {
+	for i := range watchers {
 		go func(index int) {
 			err := watchers[index].runWatch()
 			if err != nil {

--- a/apps/utils/filewatcher/main.go
+++ b/apps/utils/filewatcher/main.go
@@ -20,7 +20,7 @@ use {WATCH_FILE} for templating file path into the info string for a new task
 
 example rule:
 	frequency = "1h"
-	info_template = "{WATCH_FILE}?&param=other-param&dest=gs://folder/{HOUR_SLUG}/file.json"
+	task_template = "{WATCH_FILE}?&param=other-param&dest=gs://folder/{HOUR_SLUG}/file.json"
 	lookback = 24
 	path_template = "gs://folder/{HOUR_SLUG}/*.json"`
 )
@@ -31,7 +31,7 @@ type options struct {
 	AccessKey  string  `toml:"access_key" desc:"secret token for S3/GCS access "`
 	SecretKey  string  `toml:"secret_key" desc:"secret key for S3/GCS access "`
 	FilesTopic string  `toml:"files_topic" desc:"topic override (default is files) disable with -"`
-	InfoTopic  string  `toml:"info_topic" desc:"topic to send new task"`
+	TaskTopic  string  `toml:"task_topic" desc:"topic to send new task"`
 	Rules      []*Rule `toml:"rule"`
 }
 
@@ -39,7 +39,7 @@ type Rule struct {
 	HourLookback int    `toml:"lookback" desc:"the number of hours for looking back for files in previous directory default: 24"`
 	PathTemplate string `toml:"path_template" desc:"source file path pattern to match (supports glob style matching)"`
 	Frequency    string `toml:"frequency" desc:"the wait time between checking for new files in the path_template"`
-	InfoTemplate string `toml:"info_template" desc:"the template for the info string to send to the info_topic"`
+	TaskTemplate string `toml:"task_template" desc:"the template for the info string to send to the info_topic"`
 }
 
 func (o options) Validate() error {
@@ -65,7 +65,7 @@ func main() {
 				HourLookback: 24,
 				PathTemplate: "gs://folder/{HOUR_SLUG}/*.json",
 				Frequency:    "1h",
-				InfoTemplate: "{FILE_PATH}?&param=other-param&dest=gs://folder/{HOUR_SLUG}/file.json",
+				TaskTemplate: "{FILE_PATH}?&param=other-param&dest=gs://folder/{HOUR_SLUG}/file.json",
 			},
 		},
 	}

--- a/apps/utils/filewatcher/watcher.go
+++ b/apps/utils/filewatcher/watcher.go
@@ -170,17 +170,17 @@ func (w *watcher) sendFiles(files fileList) {
 			w.producer.Send(w.appOpt.FilesTopic, b)
 		}
 
-		if w.appOpt.InfoTopic != "" {
+		if w.appOpt.TaskTopic != "" {
 			t := tmpl.PathTime(f.Path)
-			info := tmpl.Parse(w.rule.InfoTemplate, t)
+			info := tmpl.Parse(w.rule.TaskTemplate, t)
 			info = strings.Replace(info, "{WATCH_FILE}", f.Path, -1)
 
-			tsk := task.New(w.appOpt.InfoTopic, info)
+			tsk := task.New(w.appOpt.TaskTopic, info)
 			meta := task.NewMeta()
 			meta.SetMeta("job", "filewatcher")
 			tsk.Meta = meta.GetMeta().Encode()
 			b, _ := json.Marshal(tsk)
-			w.producer.Send(w.appOpt.InfoTopic, b)
+			w.producer.Send(w.appOpt.TaskTopic, b)
 		}
 
 	}

--- a/apps/utils/recap/app_test.go
+++ b/apps/utils/recap/app_test.go
@@ -74,18 +74,18 @@ func TestDoneTopic(t *testing.T) {
 	}
 	cases := trial.Cases{
 		"task without job": {
-			Input:    `{"type":"test","info":"?date=2020-01-02","result":"complete"}`,
-			Expected: []string{"test\n\tmin: 0s max 0s avg:0s\n\tComplete   1  2020/01/02"},
+			Input:    `{"type":"test1","info":"?date=2020-01-02","result":"complete"}`,
+			Expected: []string{"test1\n\tmin: 0s max 0s avg:0s\n\tComplete   1  2020/01/02"},
 		},
 		"task with job meta": {
-			Input:    `{"type":"test","info":"?date=2020-01-02","result":"complete","meta":"job=part1"}`,
-			Expected: []string{"test:part1\n\tmin: 0s max 0s avg:0s\n\tComplete   1  2020/01/02"},
+			Input:    `{"type":"test2","info":"?date=2020-01-02","result":"complete","meta":"job=part1"}`,
+			Expected: []string{"test2:part1\n\tmin: 0s max 0s avg:0s\n\tComplete   1  2020/01/02"},
 		},
 		"2 task with job meta": {
-			Input: `{"type":"test","info":"?date=2020-01-02","result":"complete","meta":"job=part1"}
-{"type":"test","info":"?date=2020-01-02","result":"complete","meta":"job=part2"}`,
-			Expected: []string{"test:part1\n\tmin: 0s max 0s avg:0s\n\tComplete   1  2020/01/02",
-				"test:part2\n\tmin: 0s max 0s avg:0s\n\tComplete   1  2020/01/02"},
+			Input: `{"type":"test3","info":"?date=2020-01-02","result":"complete","meta":"job=part1"}
+{"type":"test3","info":"?date=2020-01-02","result":"complete","meta":"job=part2"}`,
+			Expected: []string{"test3:part1\n\tmin: 0s max 0s avg:0s\n\tComplete   1  2020/01/02",
+				"test3:part2\n\tmin: 0s max 0s avg:0s\n\tComplete   1  2020/01/02"},
 		},
 	}
 	trial.New(fn, cases).Test(t)

--- a/apps/workers/bq-load/README.md
+++ b/apps/workers/bq-load/README.md
@@ -7,8 +7,7 @@ takes one of more line deliminated json files and loads them into a bigquery tab
 
 - origin: (gs://path/file.json) - location of file to be uploaded (s3, gs or local)
 - *Insertion Option* - 1 of 3
-  - truncate: truncate the table before insertion 
-  - append: (default) append the file to the table
-  - delete: a map of key, values used to delete data before insertion 
-(delete=date:2020-01-02)
- - direct_load use this option if you would like BigQuery to load from a google storage location BigQuery auth will have to have access to this location
+  - `truncate`: truncate the table before insertion 
+  - `append`:   (default) append the file to the table
+  - `delete`:    a map of key, values used to delete data before insertion i.e., (delete=date:2020-01-02)
+  - `direct_load` use this option if you would like BigQuery to load from a google storage location BigQuery auth will have to have access to this location

--- a/apps/workers/bq-load/README.md
+++ b/apps/workers/bq-load/README.md
@@ -9,4 +9,6 @@ takes one of more line deliminated json files and loads them into a bigquery tab
 - *Insertion Option* - 1 of 3
   - truncate: truncate the table before insertion 
   - append: (default) append the file to the table
-  - delete: a map of key, values used to delete data before insertion (delete=date:2020-01-02)
+  - delete: a map of key, values used to delete data before insertion 
+(delete=date:2020-01-02)
+ - direct_load use this option if you would like BigQuery to load from a google storage location BigQuery auth will have to have access to this location

--- a/apps/workers/bq-load/main.go
+++ b/apps/workers/bq-load/main.go
@@ -20,8 +20,11 @@ info params
  - delete: map field defines the column and values to delete before inserting (delete=id:10|date:2020-01-02)
 
 
-example 
-{"task":"bq_load", "info":"gs://my/data.json?destination=project.reports.impressions&delete=date:2020-01-02|id:11"}`
+example for file reader:
+{"task":"bq_load", "info":"gs://my/data.json?dest_table=project.reports.impressions&delete=date:2020-01-02|id:11"}
+
+example for GCS reference:
+{"task":"bq_load", "info":"gs://folder/*.json?dest_table=project.reports.impressions&from_gcs=true&append=true"}`
 )
 
 type options struct {

--- a/apps/workers/bq-load/worker.go
+++ b/apps/workers/bq-load/worker.go
@@ -24,11 +24,11 @@ type worker struct {
 
 	Destination `uri:"dest_table" required:"true"` // BQ table to load data into
 
-	File      string            `uri:"origin" required:"true"`   // if not GCS ref must be file, can be folder (for GCS)
-	FromGCS   bool              `uri:"from_gcs" default:"false"` // load from GCS ref, can use wildcards *
-	Truncate  bool              `uri:"truncate"`                 //remove all data in table before insert
-	Append    bool              `uri:"append"`                   // append data to table
-	DeleteMap map[string]string `uri:"delete"`                   // map of fields with value to check and delete
+	File      string            `uri:"origin" required:"true"`      // if not GCS ref must be file, can be folder (for GCS)
+	FromGCS   bool              `uri:"direct_load" default:"false"` // load directly from GCS ref, can use wildcards *
+	Truncate  bool              `uri:"truncate"`                    //remove all data in table before insert
+	Append    bool              `uri:"append"`                      // append data to table
+	DeleteMap map[string]string `uri:"delete"`                      // map of fields with value to check and delete
 
 	delete bool
 }


### PR DESCRIPTION
* added a google cloud storage option to bq-load app
* added option for `direct_load` in the uri to use a GCS reference instead of a file reader
* updated `filewatcher` to create tasks as well as files for the bus.