### PR TITLE
add child phases to info endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,21 @@
 
-FROM alpine:3.10.2
-ADD https://github.com/kelseyhightower/confd/releases/download/v0.16.0/confd-0.16.0-linux-amd64 /usr/bin/confd
+FROM alpine:3.12
 
-RUN chmod +x /usr/bin/confd
 RUN apk add ca-certificates
 RUN apk add curl
-RUN apk add jq
+
+#confd
+ADD https://github.com/kelseyhightower/confd/releases/download/v0.16.0/confd-0.16.0-linux-amd64 /usr/bin/confd
+RUN chmod +x /usr/bin/confd
+
+#gojq
+ADD https://github.com/itchyny/gojq/releases/download/v0.12.0/gojq_v0.12.0_linux_amd64.tar.gz /tmp/jq.tar.gz
+RUN cd /tmp && tar -xzf jq.tar.gz
+RUN cp /tmp/gojq_v0.12.0_linux_amd64/gojq /usr/bin/jq
+RUN rm -rf /tmp/*
+
+#ll
+RUN echo -e "#!/bin/sh \n ls -Alhp \$1" > /usr/bin/ll
+RUN chmod +x /usr/bin/ll
 
 COPY build/ /usr/bin/

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -33,7 +33,12 @@ func (p Phase) Job() string {
 	if len(s) > 1 {
 		return s[1]
 	}
-	return s[0]
+
+	r, _ := url.ParseQuery(p.Rule)
+	if j := r.Get("job"); j != "" {
+		return j
+	}
+	return ""
 }
 
 // Topic portion of the Task


### PR DESCRIPTION
example info output 
``` json
{
  "app_name":"flowlord",
  "version":"v0.13.0 (built w/go1.15.5)",
  "runtime": "8.84s",
  "next_cache_update": "2021-01-05T14:31:35",
  "workflow": {
    "revenue.toml": 8
  },
  "cron": {
    "task.bigquery:revenue": {
      "Next": "2021-01-06T07:30:00-07:00",
      "Prev": "0001-01-01T00:00:00Z",
      "Schedule": "0 30 7 * * *",
      "Child": [
        "task.save:revenue ➞ task.sql_load:revenue"
      ]
    },
    "task.bigquery:impressions": {
      "Next": "2021-01-06T07:00:00-07:00",
      "Prev": "0001-01-01T00:00:00Z",
      "Schedule": "0 0 7 * * *"
    },
    "task.bigquery:engagements": {
      "Next": "2021-01-06T07:00:00-07:00",
      "Prev": "0001-01-01T00:00:00Z",
      "Schedule": "0 0 7 * * *"
    }
  }
}
```