### PR TITLE
flowlord: bug fix

### DIFF
--- a/apps/taskmasters/flowlord/handler.go
+++ b/apps/taskmasters/flowlord/handler.go
@@ -334,8 +334,12 @@ func (tm *taskMaster) backload(req request) response {
 		end = start
 		msg = append(msg, "to value not set")
 	}
-	if start.IsZero() && end.IsZero() && at.IsZero() {
+	if req.At == "" && req.From == "" && req.To == "" {
 		msg = append(msg, "no time provided using today")
+		at = time.Now()
+	}
+	if start.IsZero() && end.IsZero() && at.IsZero() {
+		msg = append(msg, "invalid time format (to|from|at), using today")
 		at = time.Now()
 	}
 	if !at.IsZero() {
@@ -419,7 +423,10 @@ func parseTime(s string) time.Time {
 	if err == nil {
 		return t
 	}
-	t, _ = time.Parse("2006-01-02T15", s)
+	t, err = time.Parse("2006-01-02T15", s)
+	if err == nil {
+		return t
+	}
+	t, _ = time.Parse(time.RFC3339, s)
 	return t
-
 }

--- a/apps/taskmasters/flowlord/handler_test.go
+++ b/apps/taskmasters/flowlord/handler_test.go
@@ -91,7 +91,6 @@ func TestBackloader(t *testing.T) {
 				Count: 32,
 			},
 		},
-
 		"monthly": {
 			Input: request{
 				Task:     "month",
@@ -108,7 +107,6 @@ func TestBackloader(t *testing.T) {
 				Count: 12,
 			},
 		},
-
 		"meta_template": {
 			Input: request{
 				Task:     "meta",
@@ -151,7 +149,8 @@ func TestBackloader(t *testing.T) {
 				Count: 1,
 				Tasks: []task.Task{
 					{Type: "task1", Info: "?date=2022-12-01", Meta: "workflow=f3.toml"},
-				}},
+				},
+			},
 		},
 		"backwards": {
 			Input: request{

--- a/apps/taskmasters/flowlord/taskmaster.go
+++ b/apps/taskmasters/flowlord/taskmaster.go
@@ -361,7 +361,7 @@ func (tm *taskMaster) Process(t *task.Task) error {
 			if !taskTime.IsZero() {
 				info = tmpl.Parse(info, taskTime)
 			}
-			child := task.NewWithID(p.Task, info, t.ID)
+			child := task.NewWithID(p.Topic(), info, t.ID)
 			child.Job = p.Job()
 
 			child.Meta = "workflow=" + meta.Get("workflow")

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -51,8 +51,7 @@ func TestMain(m *testing.M) {
 	// bucket
 	err = createBucket(testBucket)
 	if err != nil {
-		log.Println(err.Error())
-		os.Exit(1)
+		log.Println(err)
 	}
 
 	// create files

--- a/internal/test/workflow/jobs.toml
+++ b/internal/test/workflow/jobs.toml
@@ -1,0 +1,17 @@
+[[Phase]]
+task = "worker"
+rule = "cron=0 5 * * *?job=parent_job"
+retry = 3
+template = "?date={yyyy}-{mm}-{dd}T{hh}"
+
+[[Phase]]
+task = "worker"
+rule = "job=child1"
+dependsOn="worker:parent_job"
+retry = 3
+template = "?date={yyyy}-{mm}-{dd}T{hh}"
+
+[[Phase]]
+task = "worker:child2"
+dependsOn="worker:parent_job"
+template = "?day={yyyy}-{mm}-{dd}"

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -172,7 +172,9 @@ func (c *Cache) Children(t task.Task) []Phase {
 	result := make([]Phase, 0)
 
 	key := values.Get("workflow")
-	job := values.Get("job")
+	if t.Job == "" {
+		t.Job = values.Get("job")
+	}
 	if key == "" {
 		return nil
 	}
@@ -186,7 +188,7 @@ func (c *Cache) Children(t task.Task) []Phase {
 		}
 
 		if depends == t.Type {
-			if j == "" || j == job {
+			if j == "" || j == t.Job {
 				result = append(result, w)
 			}
 		}

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -91,7 +91,7 @@ func TestRefresh(t *testing.T) {
 		},
 		"folder": {
 			Input:    &Cache{path: "../internal/test/workflow", isDir: true},
-			Expected: 3, // load folder with 2 files
+			Expected: 4, // load folder with 2 files
 		},
 		"sub-folder": {
 			Input:    &Cache{path: "../internal/test/parent", isDir: true},
@@ -112,7 +112,7 @@ func TestRefresh(t *testing.T) {
 					"f3.toml":      {},
 				},
 			},
-			Expected: 3,
+			Expected: 4,
 		},
 		"keep loaded": {
 			Input: &Cache{
@@ -127,7 +127,7 @@ func TestRefresh(t *testing.T) {
 					},
 				},
 			},
-			Expected: 3,
+			Expected: 4,
 		},
 	}
 	trial.New(fn, cases).SubTest(t)


### PR DESCRIPTION
- start children jobs when Job field is populated
- Add support for RFC3339 time format for at, from and to. 