### PR TITLE
bug fix: add job in meta to all children

### DIFF
--- a/apps/taskmasters/flowlord/taskmaster.go
+++ b/apps/taskmasters/flowlord/taskmaster.go
@@ -368,6 +368,9 @@ func (tm *taskMaster) Process(t *task.Task) error {
 			if v := meta.Get("cron"); v != "" {
 				child.Meta += "&cron=" + v
 			}
+			if child.Job != "" {
+				child.Meta += "&job=" + child.Job
+			}
 
 			tm.taskCache.Add(*child)
 			if err := tm.producer.Send(p.Task, child.JSONBytes()); err != nil {

--- a/apps/taskmasters/flowlord/taskmaster_test.go
+++ b/apps/taskmasters/flowlord/taskmaster_test.go
@@ -53,7 +53,7 @@ func TestTaskMaster_Process(t *testing.T) {
 		}
 		sort.Slice(result, func(i, j int) bool {
 			if result[i].Type == result[j].Type {
-				return result[i].Job < result[j].Type
+				return result[i].Job < result[j].Job
 			}
 			return result[i].Type < result[j].Type
 		})
@@ -148,7 +148,7 @@ func TestTaskMaster_Process(t *testing.T) {
 					Info: "?year=2019",
 					ID:   "UUID_task1",
 					Job:  "t5",
-					Meta: "workflow=f1.toml",
+					Meta: "workflow=f1.toml&job=t5",
 				},
 			},
 		},
@@ -216,14 +216,14 @@ func TestTaskMaster_Process(t *testing.T) {
 					Type: "worker",
 					Job:  "child1",
 					ID:   "parent_ID",
-					Meta: "workflow=jobs.toml&cron=2020-01-01T08:17:23Z",
+					Meta: "workflow=jobs.toml&cron=2020-01-01T08:17:23Z&job=child1",
 					Info: "?date=2020-01-01T08",
 				},
 				{
 					Type: "worker",
 					Job:  "child2",
 					ID:   "parent_ID",
-					Meta: "workflow=jobs.toml&cron=2020-01-01T08:17:23Z",
+					Meta: "workflow=jobs.toml&cron=2020-01-01T08:17:23Z&job=child2",
 					Info: "?day=2020-01-01",
 				},
 			},


### PR DESCRIPTION
Any worker that hasn't updated to the latest version of task/task-tools will not properly save the new `Job` this causes issues to downstream processes. Keeping the job also in the meta data makes this backwards compatible. 