### PR TITLE
updated matchFolder to properly include trailing literal segments

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -404,23 +404,40 @@ func Glob(pth string, opt *Options) ([]stat.Stats, error) {
 	return glbSts, nil
 }
 
+// matchFolder resolves and returns directories that match a globbed path prefix.
+//
+// Behavior:
+//   - Splits the provided path into a parent directory and a final segment.
+//   - Recursively expands any glob/meta characters ([], *, ?) that appear in the
+//     parent directory portion, producing a concrete list of parent directories.
+//   - For each resolved parent, lists its entries and matches only subdirectories
+//     against the final segment. The final segment can be a literal or a pattern;
+//     literal is compared by equality, patterns use filepath.Match.
+//   - Returns the directories that match the final segment as stat.Stats entries.
+//
+// This function is used by Glob to support nested directory globs such as:
+//
+//	"./a/*/b[1-3]/*/file.txt"
+//
+// ensuring trailing directory segments are preserved and matched correctly.
 func matchFolder(pth string, opt *Options) (folders []stat.Stats, err error) {
-	pthDir, pattern := path.Split(strings.TrimRight(pth, "/"))
-	paths := []string{pthDir}
+	// Resolve patterns in the parent directory first, then match the final segment
+	parentDir, segment := path.Split(strings.TrimRight(pth, "/"))
 
-	// check pthDir for pattern matches
-	if strings.ContainsAny(pthDir, "[]*?") {
-		pthDir, pattern = path.Split(strings.TrimRight(pthDir, "/"))
-		sts, err := matchFolder(pthDir, opt)
+	// Expand any patterns in the parent directory by recursion
+	parentPaths := []string{parentDir}
+	if strings.ContainsAny(parentDir, "[]*?") {
+		sts, err := matchFolder(strings.TrimRight(parentDir, "/"), opt)
 		if err != nil {
 			return nil, err
 		}
-		paths = make([]string, 0)
+		parentPaths = make([]string, 0, len(sts))
 		for _, f := range sts {
-			paths = append(paths, f.Path)
+			parentPaths = append(parentPaths, f.Path)
 		}
 	}
-	for _, p := range paths {
+
+	for _, p := range parentPaths {
 		sts, err := List(p, opt)
 		if err != nil {
 			return nil, err
@@ -430,9 +447,17 @@ func matchFolder(pth string, opt *Options) (folders []stat.Stats, err error) {
 				continue
 			}
 			_, fName := path.Split(strings.TrimRight(f.Path, "/"))
-			if isMatch, err := filepath.Match(pattern, fName); err != nil {
-				return nil, err
-			} else if isMatch {
+			isMatch := false
+			if strings.ContainsAny(segment, "[]*?") {
+				if m, err := filepath.Match(segment, fName); err != nil {
+					return nil, err
+				} else if m {
+					isMatch = true
+				}
+			} else {
+				isMatch = (fName == segment)
+			}
+			if isMatch {
 				folders = append(folders, f)
 			}
 		}

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -66,10 +66,13 @@ func TestMain(m *testing.M) {
 		"test/f1/file4.gz",
 		"test/f3/file5.txt",
 		"test/f5/file-6.txt",
+		"test/other/name/z1/file1.txt",
 	}
 	os.MkdirAll("./test/f1", 0750)
 	os.MkdirAll("./test/f3", 0750)
 	os.MkdirAll("./test/f5", 0750)
+	os.MkdirAll("./test/other/name/z1", 0750)
+	os.MkdirAll("./test/other/name/z2", 0750)
 	for _, pth := range pths {
 		if err := createFile("./"+pth, &opts); err != nil {
 			log.Fatal(err)
@@ -98,6 +101,10 @@ func TestGlob_Local(t *testing.T) {
 		return files, err
 	}
 	cases := trial.Cases[string, []string]{
+		"folder_file_pattern": { // this is the bug where the last folder name is dropped
+			Input:    "./test/other/*/z1/f*.txt",
+			Expected: []string{"./test/other/name/z1/file1.txt"},
+		},
 		"star.txt": {
 			Input:    "./test/*.txt",
 			Expected: []string{"./test/file-1.txt", "./test/file2.txt"},
@@ -177,7 +184,7 @@ func TestGlob_Minio(t *testing.T) {
 func TestIterStruct(t *testing.T) {
 	fn := func(path string) (stat.Stats, error) {
 		it := NewIterator(path, nil)
-		for _ = range it.Lines() {
+		for range it.Lines() {
 		}
 		return it.Stats(), it.Error()
 	}


### PR DESCRIPTION
The current setup fails to address multiple segments properly. 
To fix this, we should parse the path into segments and iteratively match each one. 
If a segment contains wildcards, we need to match them first, ensuring the last segment is also processed correctly to build full paths correctly.